### PR TITLE
Fixes macros calling macros; fixes proper _anonymous_ marking

### DIFF
--- a/README
+++ b/README
@@ -1,12 +1,53 @@
                               ctypesgen
                               ---------
 
-                  (c) Ctypesgen developers 2007-2011
-                 http://code.google.com/p/ctypesgen/
+                  (c) Ctypesgen developers 2007-2015
+                 https://github.com/davidjamesca/ctypesgen
 
 ctypesgen is a pure-python ctypes wrapper generator. It can also
 output JSON, which can be used with Mork, which generates bindings for
 Lua, using the alien module (which binds libffi to Lua).
+
+Documentation
+-------------
+
+See https://github.com/davidjamesca/ctypesgen/wiki for full documentation.
+
+Basic Usage
+-----------
+
+This project automatically generates ctypes wrappers for header files written
+in C.
+
+For example, if you'd like to generate Neon bindings, you can do so using this
+recipe:
+
+  $ python ctypesgen.py -lneon /usr/local/include/neon/ne_*.h -o neon.py
+
+Some libraries, such as APR, need special flags to compile. You can pass these
+flags in on the command line.
+
+For example:
+
+$ FLAGS = `apr-1-config --cppflags --includes`
+$ python ctypesgen.py $FLAGS -llibapr-1.so $HOME/include/apr-1/apr*.h -o apr.py
+
+Sometimes, libraries will depend on each other. You can specify these
+dependencies using -mmodule, where module is the name of the dependency module.
+
+Here's an example for apr_util:
+
+$ python ctypesgen.py $FLAGS -llibaprutil-1.so $HOME/include/apr-1/ap[ru]*.h \
+    -mapr -o apr_util.py
+
+
+If you want JSON output (e.g. for generating Lua bindings), use
+--output-language=json. When outputting JSON, you will probably want to use
+--all-headers --builtin-symbols --no-stddef-types --no-gnu-types
+--no-python-types too.
+
+License
+-------
 
 ctypesgen is distributed under the New (2-clause) BSD License:
 http://www.opensource.org/licenses/bsd-license.php
@@ -16,11 +57,3 @@ http://sources.redhat.com/libffi/
 
 Mork, the friendly alien, can be found at:
 https://github.com/rrthomas/mork
-
-
-Usage
------
-
-To get JSON output, use --output-language=json. When outputting JSON,
-you will probably want to use --all-headers --builtin-symbols
---no-stddef-types --no-gnu-types --no-python-types too.

--- a/ctypesgen.py
+++ b/ctypesgen.py
@@ -38,7 +38,7 @@ def option_callback_libdir(option, opt, value, parser):
 import ctypesgencore
 import ctypesgencore.messages as msgs
 
-if __name__=="__main__":
+def main(givenargs):
     usage = 'usage: %prog [options] /path/to/header.h ...'
     op = optparse.OptionParser(usage=usage)
 
@@ -126,7 +126,7 @@ if __name__=="__main__":
 
     op.set_defaults(**ctypesgencore.options.default_values)
 
-    (options, args) = op.parse_args(list(sys.argv[1:]))
+    (options, args) = op.parse_args(givenargs)
     options.headers = args
 
     # Figure out what names will be defined by imported Python modules
@@ -168,3 +168,6 @@ if __name__=="__main__":
                 "specified header file(s). Perhaps you meant to run with " \
                 "--all-headers to include objects from included sub-headers? ",
                 cls = 'usage')
+
+if __name__ == "__main__":
+    main(list(sys.argv[1:]))

--- a/ctypesgencore/expressions.py
+++ b/ctypesgencore/expressions.py
@@ -258,10 +258,7 @@ class CallExpressionNode(ExpressionNode):
     def py_string(self, can_be_ctype):
         function = self.function.py_string(can_be_ctype)
         arguments = [x.py_string(can_be_ctype) for x in self.arguments]
-        if can_be_ctype:
-            return '(%s (%s))' % (function,", ".join(arguments))
-        else:
-            return '((%s (%s)).value)' % (function,", ".join(arguments))
+        return '(%s (%s))' % (function,", ".join(arguments))
 
 # There seems not to be any reasonable way to translate C typecasts
 # into Python. Ctypesgen doesn't try, except for the special case of NULL.

--- a/ctypesgencore/printer_python/printer.py
+++ b/ctypesgencore/printer_python/printer.py
@@ -186,7 +186,8 @@ class WrapperPrinter:
                         break
                 mem[0] = name
                 names.add(name)
-                unnamed_fields.append(name)
+                if type(mem[1]) is CtypesStruct:
+                  unnamed_fields.append(name)
                 struct.members[mi] = mem
 
         print >>self.file, '%s_%s.__slots__ = [' % (struct.variety, struct.tag)

--- a/test/testsuite.py
+++ b/test/testsuite.py
@@ -147,6 +147,10 @@ class SimpleMacrosTest(unittest.TestCase):
 #define minus_macro(x,y) x-y
 #define divide_macro(x,y) x/y
 #define mod_macro(x,y) x%y
+#define subcall_macro_simple(x) (A)
+#define subcall_macro_simple_plus(x) (A) + (x)
+#define subcall_macro_minus(x,y) minus_macro(x,y)
+#define subcall_macro_minus_plus(x,y,z) (minus_macro(x,y)) + (z)
 '''
         libraries = None
         self.module, output = ctypesgentest.test(header_str)
@@ -228,6 +232,32 @@ class SimpleMacrosTest(unittest.TestCase):
         x, y = 2, 5
         self.failUnlessEqual(module.mod_macro(x, y), x % y)
 
+    def test_macro_subcall_simple(self):
+        """Test use of a constant valued macro within a macro"""
+        module = self.module
+
+        self.failUnlessEqual(module.subcall_macro_simple(2), 1)
+
+    def test_macro_subcall_simple_plus(self):
+        """Test math with constant valued macro within a macro"""
+        module = self.module
+
+        self.failUnlessEqual(module.subcall_macro_simple_plus(2), 1 + 2)
+
+    def test_macro_subcall_minus(self):
+        """Test use of macro function within a macro"""
+        module = self.module
+
+        x, y = 2, 5
+        self.failUnlessEqual(module.subcall_macro_minus(x, y), x - y)
+
+    def test_macro_subcall_minus_plus(self):
+        """Test math with a macro function within a macro"""
+        module = self.module
+
+        x, y, z = 2, 5, 1
+        self.failUnlessEqual(module.subcall_macro_minus_plus(x, y, z), (x - y) + z)
+
 
 class StructuresTest(unittest.TestCase):
     """Based on structures.py
@@ -270,7 +300,10 @@ class MathTest(unittest.TestCase):
         (it is not called once per class).
         FIXME This is slightly inefficient as it is called *way* more times than it needs to be.
         """
-        header_str = '#include <math.h>\n'
+        header_str = '''
+#include <math.h>
+#define sin_plus_y(x,y) (sin(x) + (y))
+'''
         if sys.platform == "win32":
             # pick something from %windir%\system32\msvc*dll that include stdlib
             libraries = ["msvcrt.dll"]
@@ -310,6 +343,12 @@ class MathTest(unittest.TestCase):
             module.sin("foobar")
         
         self.failUnlessRaises(ctypes.ArgumentError, local_test)
+
+    def test_subcall_sin(self):
+        """Test math with sin(x) in a macro"""
+        module = self.module
+
+        self.failUnlessEqual(module.sin_plus_y(2,1), math.sin(2) + 1)
 
 
 def main(argv=None):


### PR DESCRIPTION
Fixes CallExpressionNodes for when macros call macros.  Adds some additional relevant unit tests.  Ensures that only structs/unions get marked as _anonymous_.
